### PR TITLE
[TASK] Fix env loading #SGN-392

### DIFF
--- a/src/docker/buildfiles/opt/ada/app/src/Service/PortalUrl.php
+++ b/src/docker/buildfiles/opt/ada/app/src/Service/PortalUrl.php
@@ -17,9 +17,9 @@ final class PortalUrl
         $locale ??= $this->locale->currentLocale();
         $locale ??= $this->defaultLocale;
 
-        return getenv(
+        return $_ENV[
             'ADA_PORTAL_' . strtoupper($locale)
-        );
+        ];
     }
 
     public function __toString(): string


### PR DESCRIPTION
* The .env variables weren't used when determining the Portal URL. getenv was replaced with the $_ENV superglobal to fix the issue.